### PR TITLE
Add restaurant details page

### DIFF
--- a/chai-records/src/api/getRestaurantById.ts
+++ b/chai-records/src/api/getRestaurantById.ts
@@ -1,0 +1,65 @@
+// api/getRestaurantById.ts
+import type { Restaurant } from "@/types/restaurant";
+import { supabase } from "@/utils/supabase/supabase";
+
+export async function getRestaurantById(id: string): Promise<Restaurant | null> {
+  const { data, error } = await supabase
+    .from("restaurants")
+    .select(`
+      id,
+      name,
+      slug,
+      description,
+      phone,
+      email,
+      website_url,
+      address_line1,
+      address_line2,
+      city,
+      region,
+      postal_code,
+      country_code,
+      latitude,
+      longitude,
+      is_active,
+      created_at,
+      updated_at,
+      brand_id,
+      brand:brands (
+        id,
+        name
+      )
+    `)
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) throw error;
+
+  if (!data) return null;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const row = data as any;
+
+  return {
+    id: row.id as string,
+    name: row.name as string,
+    slug: (row.slug ?? null) as string | null,
+    description: (row.description ?? null) as string | null,
+    phone: (row.phone ?? null) as string | null,
+    email: (row.email ?? null) as string | null,
+    websiteUrl: (row.website_url ?? null) as string | null,
+    addressLine1: (row.address_line1 ?? null) as string | null,
+    addressLine2: (row.address_line2 ?? null) as string | null,
+    city: (row.city ?? null) as string | null,
+    region: (row.region ?? null) as string | null,
+    postalCode: (row.postal_code ?? null) as string | null,
+    countryCode: (row.country_code ?? null) as string | null,
+    latitude: (row.latitude ?? null) as number | null,
+    longitude: (row.longitude ?? null) as number | null,
+    isActive: Boolean(row.is_active),
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string,
+    brandId: (row.brand_id ?? null) as string | null,
+    brandName: (row.brand?.name ?? null) as string | null,
+  };
+}

--- a/chai-records/src/api/getReviewsByRestaurantId.ts
+++ b/chai-records/src/api/getReviewsByRestaurantId.ts
@@ -1,0 +1,43 @@
+// api/getReviewsByRestaurantId.ts
+import type { Review } from "@/types/review";
+import { supabase } from "@/utils/supabase/supabase";
+
+export async function getReviewsByRestaurantId(restaurantId: string): Promise<Review[]> {
+  const { data, error } = await supabase
+    .from("reviews")
+    .select(`
+      id,
+      created_at,
+      rating_overall,
+      body,
+      item:items (
+        id,
+        name,
+        restaurant:restaurants (
+          id,
+          name
+        )
+      ),
+      review_images:item_images!item_images_source_review_id_fkey (
+        url,
+        is_primary
+      )
+    `)
+    .eq("item:items.restaurant_id", restaurantId)
+    .order("created_at", { ascending: false });
+
+  if (error) throw error;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (data ?? []).map((r: any) => ({
+    id: r.id as string,
+    createdAt: r.created_at as string,
+    rating: r.rating_overall as number,
+    body: (r.body ?? null) as string | null,
+    itemId: r.item.id as string,
+    itemName: r.item.name as string,
+    restaurantId: r.item.restaurant.id as string,
+    restaurantName: r.item.restaurant.name as string,
+    photoUrl: (r.review_images?.[0]?.url as string) ?? null,
+  }));
+}

--- a/chai-records/src/app/(authed)/(require-profile)/restaurants/[id]/page.tsx
+++ b/chai-records/src/app/(authed)/(require-profile)/restaurants/[id]/page.tsx
@@ -1,0 +1,24 @@
+import { notFound } from "next/navigation";
+import { getRestaurantById } from "@/api/getRestaurantById";
+import { RestaurantDetails } from "@/customComponents/restaurants/restaurantDetails";
+import { RestaurantTabs } from "@/customComponents/restaurants/restaurantTabs";
+
+export default async function RestaurantPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const restaurant = await getRestaurantById(id);
+
+  if (!restaurant) {
+    notFound();
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-6 p-4 md:p-6">
+      <RestaurantDetails restaurant={restaurant} />
+      <RestaurantTabs restaurantId={restaurant.id} restaurantName={restaurant.name} />
+    </div>
+  );
+}

--- a/chai-records/src/customComponents/restaurants/restaurantDetails.tsx
+++ b/chai-records/src/customComponents/restaurants/restaurantDetails.tsx
@@ -1,0 +1,180 @@
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { Restaurant } from "@/types/restaurant";
+
+function formatAddress(restaurant: Restaurant): string | null {
+  const lines: string[] = [];
+
+  const street = [restaurant.addressLine1, restaurant.addressLine2].filter(Boolean).join("\n");
+  if (street) lines.push(street);
+
+  const cityLine = [restaurant.city, restaurant.region, restaurant.postalCode].filter(Boolean).join(", ");
+  if (cityLine) lines.push(cityLine);
+
+  const country = restaurant.countryCode ? restaurant.countryCode.toUpperCase() : null;
+  if (country) lines.push(country);
+
+  if (lines.length === 0) return null;
+
+  return lines.join("\n");
+}
+
+function formatCoordinate(value: number | null): string | null {
+  if (value === null || Number.isNaN(value)) return null;
+  return value.toFixed(6);
+}
+
+function formatDate(value: string): string | null {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString();
+}
+
+type InfoItem = {
+  label: string;
+  value: React.ReactNode;
+};
+
+function InfoGroup({ title, items }: { title: string; items: InfoItem[] }) {
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">{title}</h3>
+      <dl className="space-y-3 text-sm">
+        {items.map((item) => (
+          <div key={item.label} className="space-y-1">
+            <dt className="text-xs font-medium uppercase text-muted-foreground/80">{item.label}</dt>
+            <dd className="text-sm text-foreground/90">{item.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function StatusBadge({ active }: { active: boolean }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold",
+        active
+          ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200"
+          : "bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-100"
+      )}
+    >
+      {active ? "Active" : "Inactive"}
+    </span>
+  );
+}
+
+export function RestaurantDetails({ restaurant }: { restaurant: Restaurant }) {
+  const address = formatAddress(restaurant);
+  const latitude = formatCoordinate(restaurant.latitude);
+  const longitude = formatCoordinate(restaurant.longitude);
+  const mapUrl = latitude && longitude ? `https://www.google.com/maps/dir/?api=1&destination=${latitude},${longitude}` : null;
+  const createdDisplay = formatDate(restaurant.createdAt);
+  const updatedDisplay = formatDate(restaurant.updatedAt);
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-2">
+          <CardTitle className="text-2xl font-semibold leading-tight">{restaurant.name}</CardTitle>
+          <div className="space-y-1 text-sm text-muted-foreground">
+            {restaurant.brandName ? <p>Part of {restaurant.brandName}</p> : null}
+            {restaurant.slug ? <p>Slug: {restaurant.slug}</p> : null}
+          </div>
+          <CardDescription className="max-w-2xl whitespace-pre-line">
+            {restaurant.description ?? "No description available for this restaurant yet."}
+          </CardDescription>
+        </div>
+        <StatusBadge active={restaurant.isActive} />
+      </CardHeader>
+
+      <CardContent>
+        <div className="grid gap-6 md:grid-cols-2">
+          <InfoGroup
+            title="Contact"
+            items={[
+              {
+                label: "Phone",
+                value: restaurant.phone ? (
+                  <a href={`tel:${restaurant.phone}`} className="hover:underline">
+                    {restaurant.phone}
+                  </a>
+                ) : (
+                  "Not provided"
+                ),
+              },
+              {
+                label: "Email",
+                value: restaurant.email ? (
+                  <a href={`mailto:${restaurant.email}`} className="hover:underline">
+                    {restaurant.email}
+                  </a>
+                ) : (
+                  "Not provided"
+                ),
+              },
+              {
+                label: "Website",
+                value: restaurant.websiteUrl ? (
+                  <a href={restaurant.websiteUrl} target="_blank" rel="noreferrer" className="hover:underline">
+                    {restaurant.websiteUrl}
+                  </a>
+                ) : (
+                  "Not provided"
+                ),
+              },
+            ]}
+          />
+
+          <InfoGroup
+            title="Location"
+            items={[
+              {
+                label: "Address",
+                value: address ? <span className="whitespace-pre-line">{address}</span> : "Not provided",
+              },
+              {
+                label: "Coordinates",
+                value:
+                  latitude && longitude ? (
+                    <span>
+                      {latitude}, {longitude}
+                    </span>
+                  ) : (
+                    "Not provided"
+                  ),
+              },
+            ]}
+          />
+        </div>
+      </CardContent>
+
+      <CardFooter className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+          {createdDisplay ? (
+            <span>
+              Created <time dateTime={restaurant.createdAt}>{createdDisplay}</time>
+            </span>
+          ) : null}
+          {updatedDisplay ? (
+            <span>
+              Updated <time dateTime={restaurant.updatedAt}>{updatedDisplay}</time>
+            </span>
+          ) : null}
+          {restaurant.brandId ? <span>Brand ID: {restaurant.brandId}</span> : null}
+        </div>
+
+        {mapUrl ? (
+          <Button asChild>
+            <a href={mapUrl} target="_blank" rel="noreferrer">
+              View on Google Maps
+            </a>
+          </Button>
+        ) : null}
+      </CardFooter>
+    </Card>
+  );
+}

--- a/chai-records/src/customComponents/restaurants/restaurantReviewsSection.tsx
+++ b/chai-records/src/customComponents/restaurants/restaurantReviewsSection.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Loader } from '@/customComponents/loader/loader';
+import { Paginate } from '@/customComponents/paginate/paginate';
+import { ReviewCard } from '@/customComponents/reviews/reviewCard';
+import { getReviewsByRestaurantId } from '@/api/getReviewsByRestaurantId';
+import type { Review } from '@/types/review';
+
+type RestaurantReviewsSectionProps = {
+  restaurantId: string;
+  restaurantName: string;
+  pageSize?: number;
+};
+
+export function RestaurantReviewsSection({
+  restaurantId,
+  restaurantName,
+  pageSize = 12,
+}: RestaurantReviewsSectionProps) {
+  const [rows, setRows] = useState<Review[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+
+    (async () => {
+      setLoading(true);
+      try {
+        const list = await getReviewsByRestaurantId(restaurantId);
+        if (alive) setRows(list);
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, [restaurantId]);
+
+  const hasReviews = rows.length > 0;
+
+  if (loading) {
+    return (
+      <div className="grid min-h-[30vh] place-items-center">
+        <Loader variant="inline" message="Loading reviews…" />
+      </div>
+    );
+  }
+
+  if (!hasReviews) {
+    return (
+      <Card className="p-6 text-sm text-muted-foreground">
+        No reviews have been posted for {restaurantName} yet.
+      </Card>
+    );
+  }
+
+  return (
+    <Paginate items={rows} pageSize={pageSize} isLoading={loading}>
+      {(pageItems) => (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {pageItems.map((r) => (
+            <ReviewCard
+              key={r.id}
+              id={r.id}
+              itemName={r.itemName}
+              restaurantName={r.restaurantName ?? restaurantName}
+              rating={r.rating}
+              body={r.body}
+              photoUrl={r.photoUrl ?? undefined}
+              createdAt={r.createdAt}
+            />
+          ))}
+        </div>
+      )}
+    </Paginate>
+  );
+}

--- a/chai-records/src/customComponents/restaurants/restaurantTabs.tsx
+++ b/chai-records/src/customComponents/restaurants/restaurantTabs.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { RestaurantReviewsSection } from '@/customComponents/restaurants/restaurantReviewsSection';
+
+type TabKey = 'reviews' | 'items';
+
+const TABS: { id: TabKey; label: string }[] = [
+  { id: 'reviews', label: 'Reviews' },
+  { id: 'items', label: 'Items' },
+];
+
+type RestaurantTabsProps = {
+  restaurantId: string;
+  restaurantName: string;
+};
+
+export function RestaurantTabs({ restaurantId, restaurantName }: RestaurantTabsProps) {
+  const [active, setActive] = useState<TabKey>('reviews');
+
+  return (
+    <div className="space-y-4">
+      <nav className="flex flex-wrap gap-2" aria-label="Restaurant sections">
+        {TABS.map((tab) => (
+          <Button
+            key={tab.id}
+            type="button"
+            variant={active === tab.id ? 'default' : 'ghost'}
+            size="sm"
+            onClick={() => setActive(tab.id)}
+            aria-pressed={active === tab.id}
+          >
+            {tab.label}
+          </Button>
+        ))}
+      </nav>
+
+      {active === 'reviews' ? (
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold">Recent reviews</h2>
+          <RestaurantReviewsSection restaurantId={restaurantId} restaurantName={restaurantName} />
+        </div>
+      ) : (
+        <Card className="p-6 text-sm text-muted-foreground">
+          Menu items for {restaurantName} will appear here once they&apos;re ready.
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/chai-records/src/types/restaurant.ts
+++ b/chai-records/src/types/restaurant.ts
@@ -1,0 +1,22 @@
+export type Restaurant = {
+  id: string;
+  name: string;
+  slug: string | null;
+  description: string | null;
+  phone: string | null;
+  email: string | null;
+  websiteUrl: string | null;
+  addressLine1: string | null;
+  addressLine2: string | null;
+  city: string | null;
+  region: string | null;
+  postalCode: string | null;
+  countryCode: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+  brandId: string | null;
+  brandName: string | null;
+};


### PR DESCRIPTION
## Summary
- add API helpers for loading restaurants and their reviews by id
- create restaurant detail and tabs components that surface contact, location, and maps link
- expose a new /restaurants/[id] route showing the restaurant info alongside a reviews tab

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c991dacc488330a60b3a5ab6532e1f