### PR TITLE
Add restaurant details page

### DIFF
--- a/chai-records/src/api/getItemById.ts
+++ b/chai-records/src/api/getItemById.ts
@@ -1,0 +1,157 @@
+// api/getItemById.ts
+import type { Item } from "@/types/item";
+import { supabase } from "@/utils/supabase/supabase";
+
+type RawImage = {
+  url?: string | null;
+  is_primary?: boolean | null;
+  sort_order?: number | null;
+};
+
+type Metadata = Record<string, unknown> | null;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function pickImageFromMetadata(metadata: Metadata): string | null {
+  if (!metadata) return null;
+
+  const candidates: string[] = [];
+  const preferredKeys = [
+    "imageUrl",
+    "image_url",
+    "photoUrl",
+    "photo_url",
+    "thumbnailUrl",
+    "thumbnail_url",
+    "image",
+  ];
+
+  for (const key of preferredKeys) {
+    const value = metadata[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      candidates.push(value.trim());
+    }
+  }
+
+  const images = metadata["images"];
+  if (Array.isArray(images)) {
+    for (const entry of images) {
+      if (typeof entry === "string" && entry.trim().length > 0) {
+        candidates.push(entry.trim());
+        continue;
+      }
+
+      if (isRecord(entry)) {
+        for (const key of preferredKeys) {
+          const value = entry[key];
+          if (typeof value === "string" && value.trim().length > 0) {
+            candidates.push(value.trim());
+          }
+        }
+
+        const nestedUrl = entry["url"];
+        if (typeof nestedUrl === "string" && nestedUrl.trim().length > 0) {
+          candidates.push(nestedUrl.trim());
+        }
+      }
+    }
+  }
+
+  return candidates.find((url) => url.length > 0) ?? null;
+}
+
+function pickImageFromGallery(images: RawImage[] | undefined, metadata: Metadata): string | null {
+  if (Array.isArray(images) && images.length > 0) {
+    const sorted = [...images].sort((a, b) => {
+      const primaryA = a?.is_primary ? 1 : 0;
+      const primaryB = b?.is_primary ? 1 : 0;
+      if (primaryA !== primaryB) return primaryB - primaryA;
+
+      const orderA = typeof a?.sort_order === "number" ? a.sort_order : Number.MAX_SAFE_INTEGER;
+      const orderB = typeof b?.sort_order === "number" ? b.sort_order : Number.MAX_SAFE_INTEGER;
+      return orderA - orderB;
+    });
+
+    for (const image of sorted) {
+      const url = image?.url;
+      if (typeof url === "string" && url.trim().length > 0) {
+        return url.trim();
+      }
+    }
+  }
+
+  return pickImageFromMetadata(metadata);
+}
+
+export async function getItemById(id: string): Promise<Item | null> {
+  const { data, error } = await supabase
+    .from("items")
+    .select(`
+      id,
+      restaurant_id,
+      name,
+      slug,
+      description,
+      category,
+      price_cents,
+      currency,
+      is_active,
+      sku,
+      metadata,
+      created_at,
+      updated_at,
+      restaurant:restaurants (
+        id,
+        name
+      ),
+      images:item_images (
+        url,
+        is_primary,
+        sort_order
+      )
+    `)
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) return null;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const row = data as any;
+  const metadata = (row.metadata ?? null) as Metadata;
+
+  let priceCents: number | null = null;
+  if (typeof row.price_cents === "number") {
+    priceCents = row.price_cents;
+  } else if (typeof row.price_cents === "string") {
+    const parsed = Number(row.price_cents);
+    priceCents = Number.isFinite(parsed) ? parsed : null;
+  }
+
+  const rawCurrency =
+    typeof row.currency === "string" && row.currency.trim().length > 0
+      ? row.currency.trim()
+      : String(row.currency ?? "ZAR");
+  const currency = rawCurrency.toUpperCase();
+  const imageUrl = pickImageFromGallery(row.images as RawImage[] | undefined, metadata);
+
+  return {
+    id: row.id as string,
+    restaurantId: row.restaurant_id as string,
+    restaurantName: (row.restaurant?.name ?? null) as string | null,
+    name: row.name as string,
+    slug: (row.slug ?? null) as string | null,
+    description: (row.description ?? null) as string | null,
+    category: row.category as string,
+    priceCents,
+    currency,
+    isActive: Boolean(row.is_active),
+    sku: (row.sku ?? null) as string | null,
+    metadata,
+    imageUrl: imageUrl ?? null,
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string,
+  } satisfies Item;
+}

--- a/chai-records/src/api/getRestaurantById.ts
+++ b/chai-records/src/api/getRestaurantById.ts
@@ -1,0 +1,65 @@
+// api/getRestaurantById.ts
+import type { Restaurant } from "@/types/restaurant";
+import { supabase } from "@/utils/supabase/supabase";
+
+export async function getRestaurantById(id: string): Promise<Restaurant | null> {
+  const { data, error } = await supabase
+    .from("restaurants")
+    .select(`
+      id,
+      name,
+      slug,
+      description,
+      phone,
+      email,
+      website_url,
+      address_line1,
+      address_line2,
+      city,
+      region,
+      postal_code,
+      country_code,
+      latitude,
+      longitude,
+      is_active,
+      created_at,
+      updated_at,
+      brand_id,
+      brand:brands (
+        id,
+        name
+      )
+    `)
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) throw error;
+
+  if (!data) return null;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const row = data as any;
+
+  return {
+    id: row.id as string,
+    name: row.name as string,
+    slug: (row.slug ?? null) as string | null,
+    description: (row.description ?? null) as string | null,
+    phone: (row.phone ?? null) as string | null,
+    email: (row.email ?? null) as string | null,
+    websiteUrl: (row.website_url ?? null) as string | null,
+    addressLine1: (row.address_line1 ?? null) as string | null,
+    addressLine2: (row.address_line2 ?? null) as string | null,
+    city: (row.city ?? null) as string | null,
+    region: (row.region ?? null) as string | null,
+    postalCode: (row.postal_code ?? null) as string | null,
+    countryCode: (row.country_code ?? null) as string | null,
+    latitude: (row.latitude ?? null) as number | null,
+    longitude: (row.longitude ?? null) as number | null,
+    isActive: Boolean(row.is_active),
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string,
+    brandId: (row.brand_id ?? null) as string | null,
+    brandName: (row.brand?.name ?? null) as string | null,
+  };
+}

--- a/chai-records/src/api/getReviewsByRestaurantId.ts
+++ b/chai-records/src/api/getReviewsByRestaurantId.ts
@@ -1,0 +1,43 @@
+// api/getReviewsByRestaurantId.ts
+import type { Review } from "@/types/review";
+import { supabase } from "@/utils/supabase/supabase";
+
+export async function getReviewsByRestaurantId(restaurantId: string): Promise<Review[]> {
+  const { data, error } = await supabase
+    .from("reviews")
+    .select(`
+      id,
+      created_at,
+      rating_overall,
+      body,
+      item:items (
+        id,
+        name,
+        restaurant:restaurants (
+          id,
+          name
+        )
+      ),
+      review_images:item_images!item_images_source_review_id_fkey (
+        url,
+        is_primary
+      )
+    `)
+    .eq("item:items.restaurant_id", restaurantId)
+    .order("created_at", { ascending: false });
+
+  if (error) throw error;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (data ?? []).map((r: any) => ({
+    id: r.id as string,
+    createdAt: r.created_at as string,
+    rating: r.rating_overall as number,
+    body: (r.body ?? null) as string | null,
+    itemId: r.item.id as string,
+    itemName: r.item.name as string,
+    restaurantId: r.item.restaurant.id as string,
+    restaurantName: r.item.restaurant.name as string,
+    photoUrl: (r.review_images?.[0]?.url as string) ?? null,
+  }));
+}

--- a/chai-records/src/app/(authed)/(require-profile)/restaurants/[id]/page.tsx
+++ b/chai-records/src/app/(authed)/(require-profile)/restaurants/[id]/page.tsx
@@ -1,0 +1,24 @@
+import { notFound } from "next/navigation";
+import { getRestaurantById } from "@/api/getRestaurantById";
+import { RestaurantDetails } from "@/customComponents/restaurants/restaurantDetails";
+import { RestaurantTabs } from "@/customComponents/restaurants/restaurantTabs";
+
+export default async function RestaurantPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const restaurant = await getRestaurantById(id);
+
+  if (!restaurant) {
+    notFound();
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-6 p-4 md:p-6">
+      <RestaurantDetails restaurant={restaurant} />
+      <RestaurantTabs restaurantId={restaurant.id} restaurantName={restaurant.name} />
+    </div>
+  );
+}

--- a/chai-records/src/customComponents/items/itemDetailsCard.tsx
+++ b/chai-records/src/customComponents/items/itemDetailsCard.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Loader } from "@/customComponents/loader/loader";
+import { getItemById } from "@/api/getItemById";
+import type { Item } from "@/types/item";
+import { cn } from "@/lib/utils";
+
+type ItemDetailsCardProps = {
+  itemId: string;
+};
+
+type DetailItem = {
+  label: string;
+  value: ReactNode;
+};
+
+function StatusBadge({ active }: { active: boolean }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold",
+        active
+          ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200"
+          : "bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-100"
+      )}
+    >
+      {active ? "Active" : "Inactive"}
+    </span>
+  );
+}
+
+function DetailGrid({ items }: { items: DetailItem[] }) {
+  if (items.length === 0) return null;
+
+  return (
+    <dl className="grid gap-4 sm:grid-cols-2">
+      {items.map((item) => (
+        <div key={item.label} className="space-y-1">
+          <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground/70">
+            {item.label}
+          </dt>
+          <dd className="text-sm text-foreground/90">{item.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function formatCategory(value: string | null): string {
+  if (!value) return "Uncategorized";
+  return value
+    .replace(/[_-]+/g, " ")
+    .toLowerCase()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function formatPrice(item: Item): string | null {
+  if (item.priceCents === null) return null;
+
+  const amount = item.priceCents / 100;
+  const currency = item.currency && item.currency.trim().length > 0 ? item.currency : "ZAR";
+
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency,
+      currencyDisplay: "symbol",
+    }).format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${currency}`;
+  }
+}
+
+function formatDate(value: string): string | null {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function titleCase(value: string): string {
+  return value
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+const METADATA_KEYS_TO_SKIP = new Set([
+  "imageUrl",
+  "image_url",
+  "photoUrl",
+  "photo_url",
+  "thumbnail",
+  "thumbnailUrl",
+  "thumbnail_url",
+  "images",
+]);
+
+function extractMetadata(metadata: Item["metadata"]): DetailItem[] {
+  if (!metadata) return [];
+
+  const entries: DetailItem[] = [];
+
+  for (const [key, rawValue] of Object.entries(metadata)) {
+    if (METADATA_KEYS_TO_SKIP.has(key)) continue;
+    if (rawValue === undefined || rawValue === null) continue;
+
+    let display: ReactNode | null = null;
+
+    if (typeof rawValue === "string") {
+      const trimmed = rawValue.trim();
+      if (trimmed.length > 0) display = trimmed;
+    } else if (typeof rawValue === "number") {
+      display = rawValue;
+    } else if (typeof rawValue === "boolean") {
+      display = rawValue ? "Yes" : "No";
+    } else if (Array.isArray(rawValue)) {
+      const values = rawValue.filter((value) => typeof value === "string" && value.trim().length > 0);
+      if (values.length > 0) display = values.map((value) => value.trim()).join(", ");
+    } else if (isRecord(rawValue)) {
+      const simpleValues = Object.entries(rawValue)
+        .filter(([, value]) => typeof value === "string")
+        .map(([, value]) => (value as string).trim())
+        .filter((value) => value.length > 0);
+      if (simpleValues.length > 0) display = simpleValues.join(", ");
+    }
+
+    if (display) {
+      entries.push({
+        label: titleCase(key),
+        value: display,
+      });
+    }
+  }
+
+  return entries.slice(0, 6);
+}
+
+function ItemImage({ imageUrl, name }: { imageUrl: string | null; name: string }) {
+  return (
+    <div className="relative aspect-video w-full overflow-hidden bg-[radial-gradient(circle_at_top,_var(--tw-gradient-stops))] from-muted via-background to-muted-foreground/20">
+      {imageUrl ? (
+        <Image
+          src={imageUrl}
+          alt={`${name} photo`}
+          fill
+          className="object-cover"
+          sizes="(max-width: 640px) 100vw, 600px"
+          priority={false}
+          unoptimized
+        />
+      ) : (
+        <div className="absolute inset-0 grid place-items-center text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground/70">
+          No image available
+        </div>
+      )}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-background/90 to-transparent" />
+    </div>
+  );
+}
+
+export function ItemDetailsCard({ itemId }: ItemDetailsCardProps) {
+  const [item, setItem] = useState<Item | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await getItemById(itemId);
+        if (!alive) return;
+
+        if (!result) {
+          setItem(null);
+          setError("This item could not be found.");
+        } else {
+          setItem(result);
+        }
+      } catch (err: unknown) {
+        if (!alive) return;
+        setError(err instanceof Error ? err.message : "Unable to load item details.");
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, [itemId]);
+
+  const metadataDetails = useMemo(() => extractMetadata(item?.metadata ?? null), [item?.metadata]);
+
+  if (loading) {
+    return (
+      <Card className="grid min-h-[28rem] place-items-center">
+        <Loader variant="inline" message="Loading item details…" />
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="p-6 text-sm text-muted-foreground">
+        {error}
+      </Card>
+    );
+  }
+
+  if (!item) {
+    return (
+      <Card className="p-6 text-sm text-muted-foreground">
+        Item not found.
+      </Card>
+    );
+  }
+
+  const price = formatPrice(item);
+  const createdDisplay = formatDate(item.createdAt);
+  const updatedDisplay = formatDate(item.updatedAt);
+
+  return (
+    <Card className="overflow-hidden">
+      <ItemImage imageUrl={item.imageUrl} name={item.name} />
+
+      <CardHeader className="space-y-4">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2 text-xs uppercase text-muted-foreground">
+              <span className="rounded-full bg-secondary/40 px-2 py-1 font-semibold tracking-wide text-secondary-foreground">
+                {formatCategory(item.category)}
+              </span>
+              {item.restaurantName ? <span>Served at {item.restaurantName}</span> : null}
+            </div>
+            <CardTitle className="text-2xl font-semibold leading-tight">{item.name}</CardTitle>
+            <CardDescription className="text-sm text-muted-foreground">
+              {item.description ?? "No description has been added for this item yet."}
+            </CardDescription>
+          </div>
+          <StatusBadge active={item.isActive} />
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-6">
+        <DetailGrid
+          items={[
+            {
+              label: "Price",
+              value: price ?? "Price not provided",
+            },
+            {
+              label: "Currency",
+              value: item.currency,
+            },
+            {
+              label: "SKU",
+              value: item.sku ?? "Not provided",
+            },
+            {
+              label: "Slug",
+              value: item.slug ?? "Not provided",
+            },
+            {
+              label: "Restaurant ID",
+              value: <code className="rounded bg-muted px-2 py-1 text-xs">{item.restaurantId}</code>,
+            },
+            {
+              label: "Item ID",
+              value: <code className="rounded bg-muted px-2 py-1 text-xs">{item.id}</code>,
+            },
+          ]}
+        />
+
+        {metadataDetails.length > 0 ? (
+          <div className="space-y-3">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Additional Details</h3>
+            <DetailGrid items={metadataDetails} />
+          </div>
+        ) : null}
+      </CardContent>
+
+      <CardFooter className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+          {createdDisplay ? (
+            <span>
+              Created <time dateTime={item.createdAt}>{createdDisplay}</time>
+            </span>
+          ) : null}
+          {updatedDisplay ? (
+            <span>
+              Updated <time dateTime={item.updatedAt}>{updatedDisplay}</time>
+            </span>
+          ) : null}
+        </div>
+
+        <Button asChild size="lg">
+          <Link href={`/restaurants/${item.restaurantId}`}>Go to restaurant</Link>
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/chai-records/src/customComponents/restaurants/restaurantDetails.tsx
+++ b/chai-records/src/customComponents/restaurants/restaurantDetails.tsx
@@ -1,0 +1,180 @@
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { Restaurant } from "@/types/restaurant";
+
+function formatAddress(restaurant: Restaurant): string | null {
+  const lines: string[] = [];
+
+  const street = [restaurant.addressLine1, restaurant.addressLine2].filter(Boolean).join("\n");
+  if (street) lines.push(street);
+
+  const cityLine = [restaurant.city, restaurant.region, restaurant.postalCode].filter(Boolean).join(", ");
+  if (cityLine) lines.push(cityLine);
+
+  const country = restaurant.countryCode ? restaurant.countryCode.toUpperCase() : null;
+  if (country) lines.push(country);
+
+  if (lines.length === 0) return null;
+
+  return lines.join("\n");
+}
+
+function formatCoordinate(value: number | null): string | null {
+  if (value === null || Number.isNaN(value)) return null;
+  return value.toFixed(6);
+}
+
+function formatDate(value: string): string | null {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString();
+}
+
+type InfoItem = {
+  label: string;
+  value: React.ReactNode;
+};
+
+function InfoGroup({ title, items }: { title: string; items: InfoItem[] }) {
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">{title}</h3>
+      <dl className="space-y-3 text-sm">
+        {items.map((item) => (
+          <div key={item.label} className="space-y-1">
+            <dt className="text-xs font-medium uppercase text-muted-foreground/80">{item.label}</dt>
+            <dd className="text-sm text-foreground/90">{item.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function StatusBadge({ active }: { active: boolean }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold",
+        active
+          ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200"
+          : "bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-100"
+      )}
+    >
+      {active ? "Active" : "Inactive"}
+    </span>
+  );
+}
+
+export function RestaurantDetails({ restaurant }: { restaurant: Restaurant }) {
+  const address = formatAddress(restaurant);
+  const latitude = formatCoordinate(restaurant.latitude);
+  const longitude = formatCoordinate(restaurant.longitude);
+  const mapUrl = latitude && longitude ? `https://www.google.com/maps/dir/?api=1&destination=${latitude},${longitude}` : null;
+  const createdDisplay = formatDate(restaurant.createdAt);
+  const updatedDisplay = formatDate(restaurant.updatedAt);
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-2">
+          <CardTitle className="text-2xl font-semibold leading-tight">{restaurant.name}</CardTitle>
+          <div className="space-y-1 text-sm text-muted-foreground">
+            {restaurant.brandName ? <p>Part of {restaurant.brandName}</p> : null}
+            {restaurant.slug ? <p>Slug: {restaurant.slug}</p> : null}
+          </div>
+          <CardDescription className="max-w-2xl whitespace-pre-line">
+            {restaurant.description ?? "No description available for this restaurant yet."}
+          </CardDescription>
+        </div>
+        <StatusBadge active={restaurant.isActive} />
+      </CardHeader>
+
+      <CardContent>
+        <div className="grid gap-6 md:grid-cols-2">
+          <InfoGroup
+            title="Contact"
+            items={[
+              {
+                label: "Phone",
+                value: restaurant.phone ? (
+                  <a href={`tel:${restaurant.phone}`} className="hover:underline">
+                    {restaurant.phone}
+                  </a>
+                ) : (
+                  "Not provided"
+                ),
+              },
+              {
+                label: "Email",
+                value: restaurant.email ? (
+                  <a href={`mailto:${restaurant.email}`} className="hover:underline">
+                    {restaurant.email}
+                  </a>
+                ) : (
+                  "Not provided"
+                ),
+              },
+              {
+                label: "Website",
+                value: restaurant.websiteUrl ? (
+                  <a href={restaurant.websiteUrl} target="_blank" rel="noreferrer" className="hover:underline">
+                    {restaurant.websiteUrl}
+                  </a>
+                ) : (
+                  "Not provided"
+                ),
+              },
+            ]}
+          />
+
+          <InfoGroup
+            title="Location"
+            items={[
+              {
+                label: "Address",
+                value: address ? <span className="whitespace-pre-line">{address}</span> : "Not provided",
+              },
+              {
+                label: "Coordinates",
+                value:
+                  latitude && longitude ? (
+                    <span>
+                      {latitude}, {longitude}
+                    </span>
+                  ) : (
+                    "Not provided"
+                  ),
+              },
+            ]}
+          />
+        </div>
+      </CardContent>
+
+      <CardFooter className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+          {createdDisplay ? (
+            <span>
+              Created <time dateTime={restaurant.createdAt}>{createdDisplay}</time>
+            </span>
+          ) : null}
+          {updatedDisplay ? (
+            <span>
+              Updated <time dateTime={restaurant.updatedAt}>{updatedDisplay}</time>
+            </span>
+          ) : null}
+          {restaurant.brandId ? <span>Brand ID: {restaurant.brandId}</span> : null}
+        </div>
+
+        {mapUrl ? (
+          <Button asChild>
+            <a href={mapUrl} target="_blank" rel="noreferrer">
+              View on Google Maps
+            </a>
+          </Button>
+        ) : null}
+      </CardFooter>
+    </Card>
+  );
+}

--- a/chai-records/src/customComponents/restaurants/restaurantReviewsSection.tsx
+++ b/chai-records/src/customComponents/restaurants/restaurantReviewsSection.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Loader } from '@/customComponents/loader/loader';
+import { Paginate } from '@/customComponents/paginate/paginate';
+import { ReviewCard } from '@/customComponents/reviews/reviewCard';
+import { getReviewsByRestaurantId } from '@/api/getReviewsByRestaurantId';
+import type { Review } from '@/types/review';
+
+type RestaurantReviewsSectionProps = {
+  restaurantId: string;
+  restaurantName: string;
+  pageSize?: number;
+};
+
+export function RestaurantReviewsSection({
+  restaurantId,
+  restaurantName,
+  pageSize = 12,
+}: RestaurantReviewsSectionProps) {
+  const [rows, setRows] = useState<Review[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+
+    (async () => {
+      setLoading(true);
+      try {
+        const list = await getReviewsByRestaurantId(restaurantId);
+        if (alive) setRows(list);
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, [restaurantId]);
+
+  const hasReviews = rows.length > 0;
+
+  if (loading) {
+    return (
+      <div className="grid min-h-[30vh] place-items-center">
+        <Loader variant="inline" message="Loading reviews…" />
+      </div>
+    );
+  }
+
+  if (!hasReviews) {
+    return (
+      <Card className="p-6 text-sm text-muted-foreground">
+        No reviews have been posted for {restaurantName} yet.
+      </Card>
+    );
+  }
+
+  return (
+    <Paginate items={rows} pageSize={pageSize} isLoading={loading}>
+      {(pageItems) => (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {pageItems.map((r) => (
+            <ReviewCard
+              key={r.id}
+              id={r.id}
+              itemName={r.itemName}
+              restaurantName={r.restaurantName ?? restaurantName}
+              rating={r.rating}
+              body={r.body}
+              photoUrl={r.photoUrl ?? undefined}
+              createdAt={r.createdAt}
+            />
+          ))}
+        </div>
+      )}
+    </Paginate>
+  );
+}

--- a/chai-records/src/customComponents/restaurants/restaurantTabs.tsx
+++ b/chai-records/src/customComponents/restaurants/restaurantTabs.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { RestaurantReviewsSection } from '@/customComponents/restaurants/restaurantReviewsSection';
+
+type TabKey = 'reviews' | 'items';
+
+const TABS: { id: TabKey; label: string }[] = [
+  { id: 'reviews', label: 'Reviews' },
+  { id: 'items', label: 'Items' },
+];
+
+type RestaurantTabsProps = {
+  restaurantId: string;
+  restaurantName: string;
+};
+
+export function RestaurantTabs({ restaurantId, restaurantName }: RestaurantTabsProps) {
+  const [active, setActive] = useState<TabKey>('reviews');
+
+  return (
+    <div className="space-y-4">
+      <nav className="flex flex-wrap gap-2" aria-label="Restaurant sections">
+        {TABS.map((tab) => (
+          <Button
+            key={tab.id}
+            type="button"
+            variant={active === tab.id ? 'default' : 'ghost'}
+            size="sm"
+            onClick={() => setActive(tab.id)}
+            aria-pressed={active === tab.id}
+          >
+            {tab.label}
+          </Button>
+        ))}
+      </nav>
+
+      {active === 'reviews' ? (
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold">Recent reviews</h2>
+          <RestaurantReviewsSection restaurantId={restaurantId} restaurantName={restaurantName} />
+        </div>
+      ) : (
+        <Card className="p-6 text-sm text-muted-foreground">
+          Menu items for {restaurantName} will appear here once they&apos;re ready.
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/chai-records/src/types/item.ts
+++ b/chai-records/src/types/item.ts
@@ -1,0 +1,17 @@
+export type Item = {
+  id: string;
+  restaurantId: string;
+  restaurantName: string | null;
+  name: string;
+  slug: string | null;
+  description: string | null;
+  category: string;
+  priceCents: number | null;
+  currency: string;
+  isActive: boolean;
+  sku: string | null;
+  metadata: Record<string, unknown> | null;
+  imageUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
+};

--- a/chai-records/src/types/restaurant.ts
+++ b/chai-records/src/types/restaurant.ts
@@ -1,0 +1,22 @@
+export type Restaurant = {
+  id: string;
+  name: string;
+  slug: string | null;
+  description: string | null;
+  phone: string | null;
+  email: string | null;
+  websiteUrl: string | null;
+  addressLine1: string | null;
+  addressLine2: string | null;
+  city: string | null;
+  region: string | null;
+  postalCode: string | null;
+  countryCode: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+  brandId: string | null;
+  brandName: string | null;
+};


### PR DESCRIPTION
## Summary
- add API helpers for loading restaurants and their reviews by id
- create restaurant detail and tabs components that surface contact, location, and maps link
- expose a new /restaurants/[id] route showing the restaurant info alongside a reviews tab
- add item detail API and card to display item metadata, pricing, and link back to the restaurant page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c991dacc488330a60b3a5ab6532e1f