### PR TITLE
feat: refresh home page for v1.2.0

### DIFF
--- a/chai-records/README.md
+++ b/chai-records/README.md
@@ -1,36 +1,34 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Chai Records
 
-## Getting Started
+Chai Records is an internal dashboard for curating South Africa's bubble tea scene. Administrators can browse restaurants, drill into individual menu items, and celebrate the community's tasting notes — all in one tidy Next.js workspace.
 
-First, run the development server:
+## Getting started
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
+pnpm install
 pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Then visit http://localhost:3000 to explore the dashboard. Supabase credentials are required for live data; without them, stubbed loading states will still preview the interface.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## What's new in v1.2.0
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+- **Review gallery with deep links.** Browse feedback through a responsive card grid that loads reviews on demand, surfaces star ratings, and opens a detail modal with quick actions to jump straight to the referenced item, restaurant, or reviewer profile.【F:chai-records/src/customComponents/reviews/reviewsSection.tsx†L1-L69】【F:chai-records/src/customComponents/reviews/reviewCard.tsx†L1-L96】【F:chai-records/src/customComponents/reviews/reviewModal.tsx†L1-L146】
+- **Richer item spotlight.** The item detail card now fetches live data, highlights consensus attributes, formats pricing automatically, and keeps critical metadata — such as SKU, slug, and timestamps — within easy reach alongside a direct restaurant link.【F:chai-records/src/customComponents/items/itemDetailsCard.tsx†L1-L213】
+- **Smarter attributes.** Attribute pills distinguish consensus highlights from supporting tags, collapse when space is tight, and even let administrators add custom descriptors on the fly when curating multi-select facets.【F:chai-records/src/customComponents/attributes/viewFacetPills.tsx†L1-L63】【F:chai-records/src/customComponents/attributes/facetPills.tsx†L1-L160】
+- **Restaurant profiles with maps.** Restaurant detail views bundle contact info, address formatting, status badges, and a one-click Google Maps launch so teams can validate locations without leaving the dashboard.【F:chai-records/src/customComponents/restaurants/restaurantDetails.tsx†L1-L143】
 
-## Learn More
+## Key areas to explore
 
-To learn more about Next.js, take a look at the following resources:
+- **Item management.** Inspect menu entries, evaluate their activation status, and cross-check the restaurant relationship from the same screen.【F:chai-records/src/customComponents/items/itemDetailsCard.tsx†L123-L213】
+- **Community insights.** Capture how guests describe their experience, including optional photos, consensus facets, and timestamps per review.【F:chai-records/src/customComponents/reviews/reviewModal.tsx†L37-L146】
+- **Location operations.** Confirm contact details, map links, and brand associations for every storefront at a glance.【F:chai-records/src/customComponents/restaurants/restaurantDetails.tsx†L59-L143】
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Tech stack
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+- Next.js App Router
+- React 19 with server components
+- Tailwind CSS v4
+- Supabase for authentication and data access
 
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Happy sipping!

--- a/chai-records/package.json
+++ b/chai-records/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-records",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/chai-records/src/app/(authed)/(require-profile)/home/page.tsx
+++ b/chai-records/src/app/(authed)/(require-profile)/home/page.tsx
@@ -18,14 +18,22 @@ export default function Home() {
       {/* App summary */}
       <section className="mb-6 rounded-lg border bg-muted/30 p-4">
         <h2 className="mb-2 flex items-center gap-2 text-lg font-semibold">
-          <Sparkles className="size-5" /> What&apos;s new in 1.1.1?
+          <Sparkles className="size-5" /> What&apos;s new in 1.2.0?
         </h2>
-        <p className="text-sm text-muted-foreground">
-          Chai Records now gives every menu item and reviewer their own spotlight. Pop open a review and jump
-          straight to a dedicated item page with photo, pricing, and community-loved facets, or visit a friend&apos;s
-          profile to see who&apos;s behind the latest recommendations. It&apos;s the same simple way to capture great
-          dishes, now with richer ways to explore them.
-        </p>
+        <div className="space-y-2 text-sm text-muted-foreground">
+          <p>
+            Reviews feel richer than ever: drop photos, ratings, and tasting notes, then open the refreshed review
+            modal to see every attribute you picked at a glance.
+          </p>
+          <p>
+            Item cards now highlight pricing, facets, and who is raving about a dish, while restaurant profiles gather
+            menus, attributes, and fresh directions with a Google Maps jump link.
+          </p>
+          <p>
+            Pop into a friend&apos;s profile to see their latest picks and follow their trail across restaurants without
+            losing your place.
+          </p>
+        </div>
       </section>
 
       {/* Current + Next */}
@@ -35,15 +43,19 @@ export default function Home() {
           <ul className="mt-3 space-y-2 text-sm">
             <li className="flex items-start gap-2">
               <CheckCircle2 className="mt-0.5 size-4" />
-              Create a review with a photo, a 1–5 rating, and notes.
+              Log a review with photos, a 1–5 rating, tasting notes, and rich attributes.
             </li>
             <li className="flex items-start gap-2">
               <CheckCircle2 className="mt-0.5 size-4" />
-              Jump from any review to see the full item details and who shared it.
+              Open an item card to see pricing, highlights, and who introduced it to the crew.
             </li>
             <li className="flex items-start gap-2">
               <CheckCircle2 className="mt-0.5 size-4" />
-              Browse a friend&apos;s public profile without leaving your own flow.
+              Explore restaurant profiles and tap the Google Maps link for a quick directions handoff.
+            </li>
+            <li className="flex items-start gap-2">
+              <CheckCircle2 className="mt-0.5 size-4" />
+              Browse a friend&apos;s public profile to see their latest finds at a glance.
             </li>
           </ul>
         </section>
@@ -53,10 +65,10 @@ export default function Home() {
             <Clock className="size-4" /> What&apos;s next
           </h3>
           <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
-            <li>Restaurant profile: richer menus, reviews across items, directions, and more.</li>
-            <li>Item insights: deeper review history, galleries, and comparisons between restaurants.</li>
-            <li>Friends: connect with friends to explore their profiles and reviews in one feed.</li>
-            <li>Favourites/Pin: a shared list of go-to items and restaurants other members can follow.</li>
+            <li>Insights: compare review history for similar dishes across restaurants.</li>
+            <li>Collections: pin favourite dishes or restaurants to share with the squad.</li>
+            <li>Friends: follow members and receive updates when new reviews drop.</li>
+            <li>Messaging: coordinate meetups right from Chai Records.</li>
           </ul>
         </section>
       </div>
@@ -67,7 +79,8 @@ export default function Home() {
           <Target className="size-4" /> The goal
         </h3>
         <p className="mt-2 text-sm text-muted-foreground">
-          Provide an easy way for people to compare similar dishes at different restuarants, see what is recommended by other enthusiasts and create a platform for people to share their cullinary experiences!
+          Provide an easy way for people to compare similar dishes at different restaurants, see what is recommended by
+          other enthusiasts, and create a platform for sharing culinary experiences.
         </p>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- update the authenticated home dashboard to spotlight the v1.2.0 features like richer reviews, item cards, restaurant profiles, and Google Maps handoff
- refresh the "What you can do today" checklist and roadmap callouts to match the latest release focus

## Testing
- pnpm lint *(fails: missing dependency `@eslint/eslintrc` in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5378f71c83309b9e73985944a7b6